### PR TITLE
Fix example syntax

### DIFF
--- a/content/guide/forms.md
+++ b/content/guide/forms.md
@@ -42,7 +42,7 @@ class MyForm extends Component {
                     type="checkbox"
                     checked={checked}
                     onClick={::this.toggle} />
-            <label>
+            </label>
         );
     }
 }


### PR DESCRIPTION
Thing is, this example still doesn't work. The `input` would seem to ignore the value of `checked` when it's updated. Tested in the REPL. [Failing example here](https://preactjs.com/repl?code=export%20default%20class%20Foo%20extends%20Component%20%7B%0A%09render(%7B%20%7D%2C%20%7B%20results%3D%5B%5D%20%7D)%20%7B%0A%09%09return%20(%0A%09%09%09%3Cdiv%3E%0A%09%09%09%09%3Ch1%20style%3D%22text-align%3Acenter%3B%22%3ECheckbox%3C%2Fh1%3E%0A%09%09%09%09%3CMyForm%20%2F%3E%0A%09%09%09%3C%2Fdiv%3E%0A%09%09)%3B%0A%09%7D%0A%7D%0A%0A%0Aclass%20MyForm%20extends%20Component%20%7B%0A%20%20%20%20toggle(e)%20%7B%0A%20%20%20%20%20%20%20%20e.preventDefault()%3B%20%20%20%2F%2F%20we%27ll%20handle%20this%2C%20thanks%0A%20%20%20%20%20%20%20%20let%20checked%20%3D%20!this.state.checked%3B%0A%20%20%20%20%20%20%20%20this.setState(%7B%20checked%20%7D)%3B%0A%20%20%20%20%7D%0A%20%20%20%20render(%7B%20%7D%2C%20%7B%20checked%20%7D)%20%7B%0A%20%20%20%20%20%20%20%20return%20(%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Clabel%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22checkbox%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20checked%3D%7Bchecked%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%3A%3Athis.toggle%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Flabel%3E%0A%20%20%20%20%20%20%20%20)%3B%0A%20%20%20%20%7D%0A%7D%0A)

