### PR TITLE
fixed logo ellipse stroke gaps

### DIFF
--- a/src/components/logo.js
+++ b/src/components/logo.js
@@ -26,8 +26,10 @@ export default class Logo extends Component {
 	}
 
 	renderEllipse(fg, deg, offset) {
+		let gapWidth = Math.sin(offset/500*Math.PI)*30+60;
+		let lineSize = 894 / 2 - gapWidth;
 		return (
-			<ellipse cx="0" cy="0" stroke-dasharray={`400 ${Math.sin(offset/500*Math.PI)*30+60}`} stroke-dashoffset={offset*10 + Math.sin(offset/100*Math.PI)*200} stroke-width="16px" rx="75px" ry="196px" fill="none" stroke={fg} transform={`rotate(${deg})`} />
+			<ellipse cx="0" cy="0" stroke-dasharray={`${lineSize} ${gapWidth}`} stroke-dashoffset={offset*10 + Math.sin(offset/100*Math.PI)*200} stroke-width="16px" rx="75px" ry="196px" fill="none" stroke={fg} transform={`rotate(${deg})`} />
 		);
 	}
 

--- a/src/components/logo.js
+++ b/src/components/logo.js
@@ -26,10 +26,10 @@ export default class Logo extends Component {
 	}
 
 	renderEllipse(fg, deg, offset) {
-		let gapWidth = Math.sin(offset/500*Math.PI)*30+60;
-		let lineSize = 894 / 2 - gapWidth;
+		let gapLength = Math.sin(offset/500*Math.PI)*30+60;
+		let lineLength = 894 / 2 - gapLength;
 		return (
-			<ellipse cx="0" cy="0" stroke-dasharray={`${lineSize} ${gapWidth}`} stroke-dashoffset={offset*10 + Math.sin(offset/100*Math.PI)*200} stroke-width="16px" rx="75px" ry="196px" fill="none" stroke={fg} transform={`rotate(${deg})`} />
+			<ellipse cx="0" cy="0" stroke-dasharray={`${lineLength} ${gapLength}`} stroke-dashoffset={offset*10 + Math.sin(offset/100*Math.PI)*200} stroke-width="16px" rx="75px" ry="196px" fill="none" stroke={fg} transform={`rotate(${deg})`} />
 		);
 	}
 


### PR DESCRIPTION
In order for the ellipse animation's stroke-dasharray trick to work seamlessly, the dasharray needs to sum to exactly the circumference of your ellipse.  Here's a close-up GIF of the problem:

![Here's a better gif to show the stroke glitches](https://cloud.githubusercontent.com/assets/7308014/17352994/ba7b8844-58f8-11e6-8564-00c14c045cf4.gif)


you can see the strokes glitching where the gaps will close pretty tight before the other end catches up.

Anyway, I did a little math and with the help of [this Wolfram search](http://www.wolframalpha.com/input/?i=ellipse+a%3D196+b%3D75+circumference) and I've got it spinning seamlessly.

Hope it's :smile:!