### PR TITLE
header animations only on hover; fixes #23

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -106,11 +106,11 @@ class NavLink extends Component {
 
 	render({ to, ...props }, { hovered }) {
 		let LinkImpl = to.path ? Link : 'a';
-		let Flair = to.flair && LINK_FLAIR[to.flair] && LINK_FLAIR[to.flair]
+		let Flair = to.flair && LINK_FLAIR[to.flair]
 		return (
 			<LinkImpl href={to.path || 'javascript:'} {...props} onMouseover={ () => this.setState ({ hovered: true }) }
 			                                                     onMouseout ={ () => this.setState ({ hovered: false }) }>
-				<Flair paused={!hovered} />
+				{ Flair && <Flair paused={!hovered} /> }
 				{ to.name || to.title }
 			</LinkImpl>
 		);

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -101,16 +101,21 @@ class NavItem extends Component {
 
 
 // depending on the type of nav link, use <Link> or <a>
-const NavLink = ({ to, ...props }) => {
-	let LinkImpl = to.path ? Link : 'a';
-	let Flair = to.flair && LINK_FLAIR[to.flair] && LINK_FLAIR[to.flair]
-	return (
-		<LinkImpl href={to.path || 'javascript:'} {...props}>
-			<Flair />
-			{ to.name || to.title }
-		</LinkImpl>
-	);
-};
+class NavLink extends Component {
+	state = { hovered: false }
+
+	render({ to, ...props }, { hovered }) {
+		let LinkImpl = to.path ? Link : 'a';
+		let Flair = to.flair && LINK_FLAIR[to.flair] && LINK_FLAIR[to.flair]
+		return (
+			<LinkImpl href={to.path || 'javascript:'} {...props} onMouseover={ () => this.setState ({ hovered: true }) }
+			                                                     onMouseout ={ () => this.setState ({ hovered: false }) }>
+				<Flair paused={!hovered} />
+				{ to.name || to.title }
+			</LinkImpl>
+		);
+	}
+}
 
 
 // get a CSS-addressable identifier for a given route

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,14 +1,14 @@
 import { h, Component } from 'preact';
 import { Link } from 'preact-router';
 import cx from 'classnames';
-import Logo from '../logo';
+import { InvertedLogo } from '../logo';
 import Search from './search';
 import style from './style';
 import config from '../../config';
 
 
 const LINK_FLAIR = {
-	logo: () => <Logo inverted />
+	logo: InvertedLogo
 };
 
 
@@ -103,9 +103,10 @@ class NavItem extends Component {
 // depending on the type of nav link, use <Link> or <a>
 const NavLink = ({ to, ...props }) => {
 	let LinkImpl = to.path ? Link : 'a';
+	let Flair = to.flair && LINK_FLAIR[to.flair] && LINK_FLAIR[to.flair]
 	return (
 		<LinkImpl href={to.path || 'javascript:'} {...props}>
-			{ to.flair && LINK_FLAIR[to.flair] && LINK_FLAIR[to.flair]() }
+			<Flair />
 			{ to.name || to.title }
 		</LinkImpl>
 	);

--- a/src/components/logo.js
+++ b/src/components/logo.js
@@ -11,7 +11,7 @@ export default class Logo extends Component {
 	};
 
 	next = () => {
-		if (!this.mounted || this.timer) return;
+		if (!this.mounted || this.props.paused || this.timer) return;
 		this.timer = (requestAnimationFrame || setTimeout)(this.frame, 15);
 	};
 
@@ -23,6 +23,10 @@ export default class Logo extends Component {
 	componentWillUnmount() {
 		(cancelAnimationFrame || clearTimeout)(this.timer);
 		this.mounted = this.timer = false;
+	}
+
+	componentDidUpdate() {
+		this.next();
 	}
 
 	renderEllipse(fg, deg, offset) {

--- a/src/components/logo.js
+++ b/src/components/logo.js
@@ -49,3 +49,9 @@ export default class Logo extends Component {
 		);
 	}
 }
+
+export const InvertedLogo = (props) => {
+	return (
+		<Logo inverted {...props}/>
+	);
+}


### PR DESCRIPTION
This solves #23 by pausing animations in the header except when the mouse is hovering over that menu item.