### PR TITLE
Adds a link to preact-i18nline

### DIFF
--- a/content/about/libraries-addons.md
+++ b/content/about/libraries-addons.md
@@ -34,6 +34,7 @@ A collection of modules built to work wonderfully with Preact.
 
 - :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
 - :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
+- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
 
 
 ### GUI Toolkits


### PR DESCRIPTION
This adds a link to [preact-i18nline](https://github.com/download/preact-i18nline), an integration of Preact with the [i18n-js](https://rubygems.org/gems/i18n-js/versions/2.1.2) ecosystem that came out of Ruby but also enjoys moderate popularity on Node.