### PR TITLE
Improve user language detection

### DIFF
--- a/src/lib/default-language.js
+++ b/src/lib/default-language.js
@@ -4,6 +4,8 @@ export default function getDefaultLanguage(available={}) {
 		if (langs[i]) {
 			let lang = String(langs[i]).toLowerCase();
 			if (available[lang]) return lang;
+			// Respect order of `navigator.languages` by returning if the fallback language `English` is found
+			if (lang === 'en') return;
 		}
 	}
 }


### PR DESCRIPTION
When a user configures the following languages in their browser:
`navigator.languages === ["en-US", "en", "de-DE", "de", "zh-TW", "zh"]`
the page currently renders in Chinese, although English should take precedence.

This PR changes that behaviour and makes sure the order of languages is respected by including English in the detection (instead of only falling back to English if no matching localisation is found).