### PR TITLE
Added Connectivity Index to the examples page.

### DIFF
--- a/content/about/demos-examples.md
+++ b/content/about/demos-examples.md
@@ -35,6 +35,8 @@ Open-Source peach.cool app.
 **[Dropfox](https://github.com/developit/dropfox)** :wolf:  
 Desktop app for Dropbox, built with Preact, Electron and Photon.
 
+**[Connectivity Index](https://cindex.co)** :iphone:  
+A site that allows you to search through [Akamai State of the Internet Connectivity Report](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) data by country.
 
 
 ## Full Demos & Examples


### PR DESCRIPTION
Connectivity Index is a Preact-powered site, and as such I feel it may be a good addition to the examples page. :) Also uses preact-render-to-string to generate server side markup.