### PR TITLE
Fix edit link in the footer after navigation to another page

### DIFF
--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -3,14 +3,14 @@ import { connect } from '../../lib/store';
 import config from '../../config';
 import style from './style';
 
-@connect( ({ lang }) => ({ lang }) )
+@connect( ({ lang, url }) => ({ lang, url }) )
 export default class Footer extends Component {
 	setLang = e => {
 		this.props.store.setState({ lang: e.target.value });
 	};
 
-	render({ lang }) {
-		let path = location.pathname.replace(/\/$/,'') || '/index';
+	render({ lang, url = location.pathname }) {
+		let path = url.replace(/\/$/,'') || '/index';
 		if (lang) path = `/lang/${lang}${path}`;
 		let editUrl = `https://github.com/developit/preact-www/tree/master/content${path}.md`;
 		return (


### PR DESCRIPTION
Steps to reproduce:

1. Open https://preactjs.com/
2. Navigate to any docs page, say **Getting Started**
3. Click **Edit this Page** link in the footer
4. You’re editing the home page (actually the first page after site was first loaded)