### PR TITLE
Remove dead links in Big Performance section

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -71,7 +71,7 @@ toc: false
     </p>
     
     <p>
-        It even includes extra performance features like <a href="/guide/configuration#debounceRendering">customizable update batching</a>, optional <a href="/guide/configuration#syncComponentUpdates">async rendering</a>, DOM recycling and optimized event handling via [Linked State](/guide/linked-state).
+        It even includes extra performance features like DOM recycling and optimized event handling via [Linked State](/guide/linked-state).
     </p>
 </section>
 

--- a/content/index.md
+++ b/content/index.md
@@ -71,7 +71,7 @@ toc: false
     </p>
     
     <p>
-        It even includes extra performance features like DOM recycling and optimized event handling via [Linked State](/guide/linked-state).
+        It even includes extra performance features like customizable update batching, optional async rendering, DOM recycling, and optimized event handling via [Linked State](/guide/linked-state).
     </p>
 </section>
 


### PR DESCRIPTION
The second paragraph in the **Big Performance** section on https://preactjs.com/ currently reads:

> It even includes extra performance features like customizable update batching, optional async rendering, DOM recycling and optimized event handling via Linked State.

The features “customizable update batching” and “optional async rendering” contain broken links that lead to 404 pages. This PR removes them, so the paragraph is simpler and contains a link to the valid guide for Linked State.