### PR TITLE
remove componentDidUnmount() lifecycle method

### DIFF
--- a/content/guide/getting-started.md
+++ b/content/guide/getting-started.md
@@ -146,7 +146,6 @@ In order to have the clock's time update every second, we need to know when `<Cl
 | `componentWillMount`        | before the component gets mounted to the DOM     |
 | `componentDidMount`         | after the component gets mounted to the DOM      |
 | `componentWillUnmount`      | prior to removal from the DOM                    |
-| `componentDidUnmount`       | after removal from the DOM                       |
 | `componentWillReceiveProps` | before new props get accepted                    |
 | `shouldComponentUpdate`     | before `render()`. Return `false` to skip render |
 | `componentWillUpdate`       | before `render()`                                |

--- a/content/guide/lifecycle-methods.md
+++ b/content/guide/lifecycle-methods.md
@@ -14,7 +14,6 @@ Preact invokes the following lifecycle methods if they are defined for a Compone
 | `componentWillMount`        | before the component gets mounted to the DOM     |
 | `componentDidMount`         | after the component gets mounted to the DOM      |
 | `componentWillUnmount`      | prior to removal from the DOM                    |
-| `componentDidUnmount`       | after removal from the DOM                       |
 | `componentWillReceiveProps` | before new props get accepted                    |
 | `shouldComponentUpdate`     | before `render()`. Return `false` to skip render |
 | `componentWillUpdate`       | before `render()`                                |

--- a/content/lang/es/guide/getting-started.md
+++ b/content/lang/es/guide/getting-started.md
@@ -146,7 +146,6 @@ Para lograr que el tiempo de reloj sea actualizado cada segundo, necesitamos sab
 | `componentWillMount`        | previo a que el componente sea montado en el DOM             |
 | `componentDidMount`         | luego de que el componente es montado en el DOM              |
 | `componentWillUnmount`      | previo a la eliminación del componente del DOM               |
-| `componentDidUnmount`       | luego de la eliminación del componente del DOM               |
 | `componentWillReceiveProps` | previo a que nuevas props sean aceptadas                     |
 | `shouldComponentUpdate`     | previo a `render()`. Devuelve `false` para evitar el render  |
 | `componentWillUpdate`       | previo a `render()`                                          |

--- a/content/lang/es/guide/lifecycle-methods.md
+++ b/content/lang/es/guide/lifecycle-methods.md
@@ -14,7 +14,6 @@ Preact invoca los siguientes métodos del ciclo en caso de que estén definidos 
 | `componentWillMount`        | antes de montar el componente en el DOM                     |
 | `componentDidMount`         | después de montar el componente en el DOM                   |
 | `componentWillUnmount`      | antes de remover el componente del DOM                      |
-| `componentDidUnmount`       | después de remover el componente del DOM                    |
 | `componentWillReceiveProps` | antes de recibir nuevas propiedades                         |
 | `shouldComponentUpdate`     | antes de `render()`. Devolver `false` para evitar el render |
 | `componentWillUpdate`       | antes de `render()`                                         |

--- a/content/lang/pt-br/guide/getting-started.md
+++ b/content/lang/pt-br/guide/getting-started.md
@@ -146,7 +146,6 @@ De modo a ter o tempo do Relógio atualizado a cada segundo, precisamos saber qu
 | `componentWillMount`        | antes do componente ser montado no DOM 			     							|
 | `componentDidMount`         | depois do componente ser montado no DOM    			 							|
 | `componentWillUnmount`      | antes da remoção do Componente do DOM 					 							|
-| `componentDidUnmount`       | depois da remoção do Componente do DOM 					 							|
 | `componentWillReceiveProps` | antes das novas props serem aceitas 						 						 	|
 | `shouldComponentUpdate`     | antes de `render()`. Retorne `false` para pular a renderização|
 | `componentWillUpdate`       | antes de `render()`                              							|

--- a/content/lang/pt-br/guide/lifecycle-methods.md
+++ b/content/lang/pt-br/guide/lifecycle-methods.md
@@ -15,9 +15,7 @@ Preact invoca os seguintes métodos do ciclo de vida se os mesmos estiverem defi
 | `componentWillMount`        | antes do componente ser montado no DOM 			     							|
 | `componentDidMount`         | depois do componente ser montado no DOM    			 							|
 | `componentWillUnmount`      | antes da remoção do Componente do DOM 					 							|
-| `componentDidUnmount`       | depois da remoção do Componente do DOM 					 							|
 | `componentWillReceiveProps` | antes das novas props serem aceitas 						 						 	|
 | `shouldComponentUpdate`     | antes de `render()`. Retorne `false` para pular a renderização|
 | `componentWillUpdate`       | antes de `render()`                              							|
 | `componentDidUpdate`        | depois de `render()`                             							|
-

--- a/content/lang/zh/guide/getting-started.md
+++ b/content/lang/zh/guide/getting-started.md
@@ -145,7 +145,6 @@ render(<Clock />, document.body);
 | `componentWillMount`        | 在一个组件被渲染到 DOM 之前                         |
 | `componentDidMount`         | 在一个组件被渲染到 DOM 之后      					 |
 | `componentWillUnmount`      | 在一个组件在 DOM 中被清除之前                       |
-| `componentDidUnmount`       | 在一个组件在 DOM 中被清除之后                       |
 | `componentWillReceiveProps` | 在新的 props 被接受之前                              |
 | `shouldComponentUpdate`     | 在 `render()` 之前. 若返回 `false`，则跳过 render   |
 | `componentWillUpdate`       | 在 `render()` 之前                                |

--- a/content/lang/zh/guide/lifecycle-methods.md
+++ b/content/lang/zh/guide/lifecycle-methods.md
@@ -14,7 +14,6 @@ permalink: '/guide/lifecycle-methods'
 | `componentWillMount`        | 在 component 插入 DOM 前调用    |
 | `componentDidMount`         | 在 component 插入 DOM 后调用       |
 | `componentWillUnmount`      | 在 component 移除前调用                   |
-| `componentDidUnmount`       | 在 component 移除后调用                          |
 | `componentWillReceiveProps` | 在 component 获取新的 props 前调用                    |
 | `shouldComponentUpdate`     | 在 `render()` 返回 `false` 来跳过渲染前调用 |
 | `componentWillUpdate`       | 在 `render()`  调用之前                              |


### PR DESCRIPTION
removing the the non-standard lifecycle method  `componentDidUnmount()` from the docs.

