### PR TITLE
remove objects as class from the docs

### DIFF
--- a/content/guide/differences-to-react.md
+++ b/content/guide/differences-to-react.md
@@ -45,7 +45,6 @@ Preact actually adds a few convenient features inspired by work in the React com
 - [Linked State] updates state when inputs change automatically
 - Batching of DOM updates, debounced/collated using `setTimeout(1)` _(can also use requestAnimationFrame)_
 - You can just use `class` for CSS classes. `className` is still supported, but `class` is preferred.
-- Setting `class` to an Object creates a String className containing the keys having truthy values.
 - Component and element recycling/pooling.
 
 

--- a/content/lang/es/guide/differences-to-react.md
+++ b/content/lang/es/guide/differences-to-react.md
@@ -45,7 +45,6 @@ Preact de hecho agrega algunas características convenientes inspiradas en el tr
 - [Estado conectado] actualiza el estado automáticamente cuando el input cambia
 - Batching de actualizaciones del DOM, demorado usando `setTimeout(1)` _(también puede usar requestAnimationFrame)_
 - Puedes usar `class` para clases de CSS. `className` es soportado, pero `class` es privilegiado.
-- Usando `class` como un objeto crea un String className conteniendo las claves que tienen valores que evalúan como verdadero.
 - Reciclado y agrupamiento de Componentes y elementos.
 
 

--- a/content/lang/pt-br/guide/differences-to-react.md
+++ b/content/lang/pt-br/guide/differences-to-react.md
@@ -43,7 +43,6 @@ Preact na verdade adiciona algumas características conveninentes inspiradas pel
 - [Linked State] atualiza o estado quando os _inputs_ mudam automaticamente
 - Atualização de DOM em lotes, 'debounced/collated' usando `setTimeout(1)` _(também pode utilizar requestAnimationFrame)_
 - Você pode utilizar apenas `class` pra classes CSS. `classNames` ainda é suportado, mas `class` é preferível.
-- Definir `class` em um Objeto cria uma String `className` contendo as chaves que tem valor _truthy_
 - Reciclagem/_pooling_ de elementos e componentes.
 
 

--- a/content/lang/zh/guide/differences-to-react.md
+++ b/content/lang/zh/guide/differences-to-react.md
@@ -39,12 +39,11 @@ Preact 没尝试去包括 React 的每一个特性，是因为它想保持 **轻
 
 Preact 实际上添加了几个更为便捷的特性，灵感源于 React 的社区
 
-- `this.props` 和 `this.state` 帮你传进了 `render()` 作为参数 
+- `this.props` 和 `this.state` 帮你传进了 `render()` 作为参数
     - _你仍然可以手动地去引用它们，但这个特性更为简洁，尤其是做 [赋值解构] 的时候_
 - [Linked State] 当 inputs 输入框改变的时候，会自动更新状态 state
 - 批量 DOM 更新，`setTimeout(1)` 进行函数节流 使用 _(也可以使用 requestAnimationFrame)_
 - 你可以只用 `class` 作为 CSS 的类。 `className` 也仍然被支持， 但推荐使用 `class`
-- 给一个对象设置 `class` 创建了一个包含可信的键值的字符串类名
 - 组件和元素循环使用 / 存入池中
 
 


### PR DESCRIPTION
Remove this description from the docs, since it no longer exists in Preact 8
Related to #126 