### PR TITLE
Fix broken link

### DIFF
--- a/content/guide/getting-started.md
+++ b/content/guide/getting-started.md
@@ -106,7 +106,7 @@ Rendering hyperscript with a virtual DOM is pointless, though. We want to render
 
 ## Components
 
-Preact exports a generic `Component` class, which can be extended to build encapsulated, self-updating pieces of a User Interface.  Components support all of the standard React [lifecycle methods][#the-component-lifecycle], like `shouldComponentUpdate()` and `componentWillReceiveProps()`.  Providing specific implementations of these methods is the preferred mechanism for controlling _when_ and _how_ components update.
+Preact exports a generic `Component` class, which can be extended to build encapsulated, self-updating pieces of a User Interface.  Components support all of the standard React [lifecycle methods](#the-component-lifecycle), like `shouldComponentUpdate()` and `componentWillReceiveProps()`.  Providing specific implementations of these methods is the preferred mechanism for controlling _when_ and _how_ components update.
 
 Components also have a `render()` method, but unlike React this method is passed `(props, state)` as arguments. This provides an ergonomic means to destructure `props` and `state` into local variables to be referenced from JSX.
 


### PR DESCRIPTION
You should use [text](URL) for links in markdown.