### PR TITLE
Add Babel 7 version in getting-started

### DIFF
--- a/content/guide/getting-started.md
+++ b/content/guide/getting-started.md
@@ -49,7 +49,7 @@ Instead of declaring the `@jsx` pragma in your code, it's best to configure it g
 > { "jsxPragma": "h" }
 > ```
 >
-> **For Babel 6:**
+> **For Babel 6 and 7:**
 >
 > ```json
 > {
@@ -66,7 +66,7 @@ Instead of declaring the `@jsx` pragma in your code, it's best to configure it g
 > { "jsxPragma": "preact.h" }
 > ```
 >
-> **For Babel 6:**
+> **For Babel 6 and 7:**
 >
 > ```json
 > {


### PR DESCRIPTION
Saw that while reviewing the french version. We didn't change the API in Babel 7.