### PR TITLE
Update URL for Company "cards" to andcards.com

### DIFF
--- a/content/about/we-are-using.md
+++ b/content/about/we-are-using.md
@@ -220,7 +220,7 @@ permalink: '/about/we-are-using'
         </a>
     </li>
     <li>
-        <a href="//try.cards" target="_blank">
+        <a href="//andcards.com" target="_blank">
             <img src="/assets/we-are-using/cards.png" alt="Cards">
             Cards
         </a>


### PR DESCRIPTION
As mentioned in developit/preact#991 the companies Domain changed to https://andcards.com/
* [Old website in google cache](http://webcache.googleusercontent.com/search?q=cache:9bWzF1YN9DEJ:try.cards/).
* [New company website](https://andcards.com/)