### PR TITLE
Change Open Collective Logo to use CSS

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -131,16 +131,9 @@ const getRouteIdent = route => (
 );
 
 const Corner = () => (
-	<a href="https://opencollective.com/preact" target="_blank" class={style.corner} aria-label="Help support us">
-		<svg width="100" height="100" viewBox="0 0 100 100"
-		     style="position: absolute; top: 0; border: 0; right: 0" aria-hidden="true">
-			<path d="M0,0 L100,100 L100,0 Z" />
-			<text x="70" y="-30" transform="rotate(45)" style="text-anchor: middle">
-				Help
-			</text>
-			<text x="70" y="-10" transform="rotate(45)" style="text-anchor: middle">
-				Support Us !
-			</text>
-		</svg>
+	<a href="https://opencollective.com/preact" target="_blank" class={style.corner}>
+		<div class={style.cornerText}>
+			Help Support Us !
+		</div>
 	</a>
 );

--- a/src/components/header/style.less
+++ b/src/components/header/style.less
@@ -364,26 +364,38 @@
 }
 
 // corner link
+@corner-size: 140px;
 .corner {
 	@media (max-width: @header-mobile-breakpoint) {
 		display: none;
 	}
 
-	svg {
-		-webkit-filter: drop-shadow(0 10px 10px rgba(0, 0, 0, 0.5));
-		filter: drop-shadow(0 10px 10px rgba(0, 0, 0, 0.5));
+	display: flex;
+	justify-content: center;
+	color: #fff;
+	background-color: #f2777a;
+	height: @corner-size;
+	width: @corner-size;
+	position: absolute;
+	right: @corner-size * -.5;
+	top: @corner-size * -.5;
+	transform: rotate(45deg);
+	box-shadow: 0 0 20px 5px rgba(0, 0, 0, .5);
 
-		path {
-			fill: #f2777a;
-		}
-
-		&:hover path {
-			fill: darken(#f2777a, 5%);
-		}
-
-		text {
-			fill: #fff;
-			font-size: 16px;
-		}
+	&:hover, &:focus {
+		background-color: darken(#f2777a, 5%);
+		text-decoration: none;
+		color: #fff;
 	}
+
 }
+
+.cornerText {
+	align-self: flex-end;
+	display: inline-block;
+	font-size: 16px;
+	width: 100px;
+	padding: 0 3px 5px;
+	line-height: 1.3;
+}
+


### PR DESCRIPTION
Change from svg component and rotate to prevent open collective link from covering page fixing #200. I tried to match the existing corner link as close as possible while using css to rotate to prevent the link from blocking underlying areas on the page.

**Before (SVG)**

![before screenshot](https://user-images.githubusercontent.com/1062039/36704152-ab6866d4-1b24-11e8-9241-c2f5006456d1.png)

**After (CSS)**

![after screenshot](https://user-images.githubusercontent.com/1062039/36704159-b082f4ea-1b24-11e8-95a5-8fc08b3d12c0.png)

**Pixelmatch (Diff)**

![pixelmatch diff](https://user-images.githubusercontent.com/1062039/36704169-bbf59c9c-1b24-11e8-8191-9c0e6c1c8f0c.png)

No more blocking!
<img width="223" alt="chrome devtools" src="https://user-images.githubusercontent.com/1062039/36704238-223ad328-1b25-11e8-9d5c-12b0ef6b4487.png">
