### PR TITLE
Small grammar correction in differences-to-react guide.

### DIFF
--- a/content/guide/differences-to-react.md
+++ b/content/guide/differences-to-react.md
@@ -5,7 +5,7 @@ permalink: '/guide/differences-to-react'
 
 # Differences to React
 
-Preact itself is not intended to be a reimplementation of React.  There are differences.  Many of these differences are trivial, or can be completely removed by using [preact-compat], which is an thin layer over Preact that attempts to achieve 100% compatibility with React.
+Preact itself is not intended to be a reimplementation of React.  There are differences.  Many of these differences are trivial, or can be completely removed by using [preact-compat], which is a thin layer over Preact that attempts to achieve 100% compatibility with React.
 
 The reason Preact does not attempt to include every single feature of React is in order to remain **small** and **focused** - otherwise it would make more sense to simply submit optimizations to the React project, which is already a very complex and well-architected codebase.
 


### PR DESCRIPTION
Just changed 'an' to 'a' which seems more appropriate.