### PR TITLE
getting-started.md - Change preact boilerplate to preact cli

### DIFF
--- a/content/guide/getting-started.md
+++ b/content/guide/getting-started.md
@@ -8,7 +8,7 @@ permalink: '/guide/getting-started'
 This guide walks through building a simple "ticking clock" component. More detailed information for each topic can be found in the dedicated pages under the Guide menu.
 
 
-> :information_desk_person: You [don't _have_ to use ES2015 to use Preact](https://github.com/developit/preact-without-babel)... but you should. This guide assumes you have some sort of ES2015 build set up using babel and/or webpack/browserify/gulp/grunt/etc.  If you don't, start with [preact-boilerplate] or a [CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010).
+> :information_desk_person: You [don't _have_ to use ES2015 to use Preact](https://github.com/developit/preact-without-babel)... but you should. This guide assumes you have some sort of ES2015 build set up using babel and/or webpack/browserify/gulp/grunt/etc.  If you don't, start with [preact-cli] or a [CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010).
 
 
 ---


### PR DESCRIPTION
As a new user it was an odd experience opening the boilerplate to be told to use the CLI. I felt it made more sense to just update the link to point to the cli and not the boilerplate.