### PR TITLE
Add BitMidi to list of demo sites

### DIFF
--- a/content/about/demos-examples.md
+++ b/content/about/demos-examples.md
@@ -49,6 +49,10 @@ Embed Hacker News comment tree below your blog article.
 Blazing fast & offline frontend playground.
 [Github Project](https://github.com/chinchang/web-maker)
 
+**[BitMidi](https://bitmidi.com/)** :musical_keyboard:
+Wayback machine for free MIDI files
+[Github Project](https://github.com/feross/bitmidi.com)
+
 ## Full Demos & Examples
 
 **[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  


### PR DESCRIPTION
BitMidi is powered by Preact! This PR adds the website [BitMidi](https://bitmidi.com) to the list of demo sites.

Website screenshot: 

<img width="1085" alt="bitmidi-screenshot" src="https://user-images.githubusercontent.com/121766/45197926-84192600-b218-11e8-9db2-e54cce3c89e3.png">

Context about the site:

BitMidi is a historical archive of MIDI files from the early web era. It's a fun way to experience the early web aesthetic of Geocities and Angelfire sites, and also a powerful tool for musicians to find "song stems" to use as the basis for song remixes. It uses the latest modern web technology including WebAssembly and Web Audio to bring MIDI back to life.
