### PR TITLE
Add @storybook/preact to libraries-addons

### DIFF
--- a/content/about/libraries-addons.md
+++ b/content/about/libraries-addons.md
@@ -47,6 +47,7 @@ A collection of modules built to work wonderfully with Preact.
 - :rocket: [**preact-photon**](https://git.io/preact-photon): build beautiful desktop UI with [photon](http://photonkit.com)
 - :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui): [Weui](https://github.com/afeiship/preact-weui) for Preact
 - 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid): [Fluid](https://github.com/ajainvivek/preact-fluid) minimal UI kit for Preact
+- :book: [**storybook-preact**](https://github.com/storybooks/storybook/tree/next/app/preact): Storybook for Preact is a UI development environment for your Preact components
 
 ### Testing
 


### PR DESCRIPTION
It's now possible to create a storybook environment specifically for Preact components (https://www.npmjs.com/package/@storybook/preact). I'm not entirely sure under which sub-heading to put it, but I felt it belonged most with the GUI Toolkits.