### PR TITLE
willComponentUpdate missing from example on lifecycle methods

### DIFF
--- a/content/guide/api-reference.md
+++ b/content/guide/api-reference.md
@@ -49,6 +49,7 @@ import { Component } from 'preact';
 
 class MyComponent extends Component {
 	shouldComponentUpdate(nextProps, nextState) {}
+    willComponentUpdate(nextProps, nextState) {}
 	componentWillReceiveProps(nextProps, nextState) {
 		this.props // Previous props
 		this.state // Previous state


### PR DESCRIPTION
I noticed this lifecycle method was missing from the documentation. Dunno if we wanna add it in?